### PR TITLE
fix: correct YouTube live stream dates using yt-dlp metadata timestamp

### DIFF
--- a/app/database/item_repository.go
+++ b/app/database/item_repository.go
@@ -3,6 +3,7 @@ package database
 import (
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/lib/pq"
 	"github.com/lysyi3m/rss-comb/app/types"
@@ -304,6 +305,18 @@ func (r *ItemRepository) GetAllActiveMediaPaths() ([]string, error) {
 	}
 
 	return paths, nil
+}
+
+func (r *ItemRepository) UpdateItemPublishedAt(itemID string, publishedAt time.Time) error {
+	_, err := r.db.Exec(`
+		UPDATE feed_items SET published_at = $2 WHERE id = $1
+	`, itemID, publishedAt)
+
+	if err != nil {
+		return fmt.Errorf("failed to update item published_at: %w", err)
+	}
+
+	return nil
 }
 
 func (r *ItemRepository) UpdateContentExtractionStatus(itemID, status, content string) error {

--- a/app/jobs/handlers.go
+++ b/app/jobs/handlers.go
@@ -205,6 +205,16 @@ func DownloadMediaHandler(
 			return fmt.Errorf("failed to update media status: %w", err)
 		}
 
+		// Update published_at from yt-dlp metadata — the Atom feed's <published>
+		// date for live streams reflects when the stream was scheduled, not when
+		// the VOD became available.
+		if videoInfo.UploadTimestamp > 0 {
+			publishedAt := time.Unix(videoInfo.UploadTimestamp, 0)
+			if err := itemRepo.UpdateItemPublishedAt(*job.ItemID, publishedAt); err != nil {
+				slog.Warn("Failed to update published_at from yt-dlp metadata", "item_id", *job.ItemID, "error", err)
+			}
+		}
+
 		slog.Info("Media downloaded successfully", "item_id", *job.ItemID, "media_path", path, "size", size, "duration", duration)
 		return nil
 	}

--- a/app/media/downloader.go
+++ b/app/media/downloader.go
@@ -64,9 +64,10 @@ type VideoInfo struct {
 	LiveStatus       string
 	Duration         int
 	ReleaseTimestamp  int64
+	UploadTimestamp   int64
 }
 
-// GetVideoInfo returns video metadata (live status, duration, release time) from yt-dlp.
+// GetVideoInfo returns video metadata (live status, duration, release time, upload timestamp) from yt-dlp.
 func GetVideoInfo(ctx context.Context, ytdlpCmd, url string) (VideoInfo, error) {
 	checkCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
@@ -91,6 +92,7 @@ func GetVideoInfo(ctx context.Context, ytdlpCmd, url string) (VideoInfo, error) 
 		LiveStatus       string  `json:"live_status"`
 		Duration         float64 `json:"duration"`
 		ReleaseTimestamp  *int64  `json:"release_timestamp"`
+		Timestamp        *int64  `json:"timestamp"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &metadata); err != nil {
 		return VideoInfo{}, fmt.Errorf("failed to parse yt-dlp metadata: %w", err)
@@ -102,6 +104,9 @@ func GetVideoInfo(ctx context.Context, ytdlpCmd, url string) (VideoInfo, error) 
 	}
 	if metadata.ReleaseTimestamp != nil {
 		info.ReleaseTimestamp = *metadata.ReleaseTimestamp
+	}
+	if metadata.Timestamp != nil {
+		info.UploadTimestamp = *metadata.Timestamp
 	}
 
 	return info, nil


### PR DESCRIPTION
  YouTube Atom feeds report the scheduled/live start time as <published>
  for live streams, not the VOD availability time. After successful media
  download, update published_at from yt-dlp's authoritative timestamp
  field which reflects when the video actually became available.