### PR TITLE
feat: add min_duration setting to skip short YouTube videos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,7 @@ rss-comb/
 7. **Media System** (`app/media/`)
    - Audio extraction from YouTube videos via configurable yt-dlp command (`YT_DLP_CMD`)
    - GUID-based file naming (YouTube video ID extracted from `yt:video:` GUID)
+   - Min-duration filtering: skips videos below configured threshold before downloading (checked via yt-dlp metadata)
    - Three-layer dedup: DB lookup → filesystem check → download
    - Global media cleanup removes orphaned files not referenced by any feed
    - Supports local yt-dlp binary or Docker-based execution
@@ -235,7 +236,7 @@ rss-comb/
 - `feed_type.go`: `FeedType` interface with `Parse()` and `Build()` methods; `ForType()` factory function
 - `basic.go`: `basicType` — standard RSS/Atom parsing and RSS 2.0 building, no iTunes metadata
 - `podcast.go`: `podcastType` — RSS/Atom with iTunes metadata preservation and enclosure passthrough
-- `youtube.go`: `youtubeType` — YouTube Atom parsing with `media:group` extraction; RSS 2.0 building with downloaded audio enclosures
+- `youtube.go`: `youtubeType` — YouTube Atom parsing with `media:group` extraction; RSS 2.0 building with downloaded audio enclosures; supports `min_duration` filtering
 - `helpers.go`: Shared parsing/building utilities (URL normalization, content hashing, XML element writing, channel header, iTunes elements)
 - `config_loader.go`: Pure functions for loading and validating YAML configuration files
 - `config_sync.go`: `ConfigSync()` — syncs YAML config to database via `LoadConfig` + `UpsertFeedConfig`
@@ -352,6 +353,7 @@ settings:
   max_items: 50           # Limits RSS output items (all items stored in database)
   timeout: 30             # seconds
   extract_content: true   # Enable automatic content extraction (basic type only)
+  min_duration: 300       # Skip videos shorter than 5 minutes (youtube type only, in seconds)
 
 filters:
   - field: "title"
@@ -365,7 +367,7 @@ filters:
 **Feed Types:**
 - **basic** (default, no `type:` needed): Standard RSS/Atom normalization with filtering and deduplication. Supports `extract_content`.
 - **podcast**: Preserves iTunes podcast metadata and enclosures from source feed.
-- **youtube**: Parses YouTube Atom feeds, downloads audio via yt-dlp, generates podcast RSS with media enclosures.
+- **youtube**: Parses YouTube Atom feeds, downloads audio via yt-dlp, generates podcast RSS with media enclosures. Supports `min_duration` to skip short videos (e.g., teasers).
 
 **Filter Pattern Types:**
 RSS Comb supports two pattern matching modes that can be used together:

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ settings:
   max_items: 50                # Limits RSS output items (all items stored in database)
   timeout: 30                  # seconds
   extract_content: false       # Enable automatic content extraction (basic type only)
+  min_duration: 300            # Skip videos shorter than 5 minutes (youtube type only, in seconds)
 
 filters:
   - field: "title"
@@ -159,6 +160,7 @@ filters:
 - Feed titles are automatically extracted from the source, or can be overridden with `title:`
 - `max_items` limits RSS output only - all items are stored in database
 - `extract_content: true` enables automatic full-text content extraction from article URLs
+- `min_duration: 300` skips YouTube videos shorter than the threshold (in seconds) before downloading
 - Deduplication is automatic and always enabled
 - Filters support `title`, `description`, `content`, `authors`, `link`, and `categories` fields
 - **Filter patterns**: Use substring matching (`"text"`) or regex patterns (`"/pattern/"`) - both can be mixed together

--- a/app/feed/config_loader.go
+++ b/app/feed/config_loader.go
@@ -65,6 +65,14 @@ func validateConfig(config *Config) error {
 		return fmt.Errorf("extract_content is only supported for basic (no type) feeds")
 	}
 
+	if config.Settings.MinDuration < 0 {
+		return fmt.Errorf("min_duration must be >= 0")
+	}
+
+	if config.Settings.MinDuration > 0 && config.Type != "youtube" {
+		return fmt.Errorf("min_duration is only supported for youtube feeds")
+	}
+
 	for i, filter := range config.Filters {
 		if filter.Field == "" {
 			return fmt.Errorf("filter %d: field is required", i)

--- a/app/feed/config_loader_test.go
+++ b/app/feed/config_loader_test.go
@@ -130,6 +130,41 @@ settings:
 	}
 }
 
+func TestLoadConfig_MinDurationOnlyForYouTube(t *testing.T) {
+	dir := t.TempDir()
+	writeTestConfig(t, dir, "test-feed.yml", `
+url: "https://example.com/feed.xml"
+type: podcast
+enabled: true
+settings:
+  min_duration: 300
+`)
+
+	_, _, err := LoadConfig(dir, "test-feed")
+	if err == nil {
+		t.Error("expected error for min_duration on non-youtube type")
+	}
+}
+
+func TestLoadConfig_MinDurationValidForYouTube(t *testing.T) {
+	dir := t.TempDir()
+	writeTestConfig(t, dir, "test-feed.yml", `
+url: "https://example.com/feed.xml"
+type: youtube
+enabled: true
+settings:
+  min_duration: 300
+`)
+
+	config, _, err := LoadConfig(dir, "test-feed")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if config.Settings.MinDuration != 300 {
+		t.Errorf("expected min_duration 300, got %d", config.Settings.MinDuration)
+	}
+}
+
 func TestLoadConfig_MissingURL(t *testing.T) {
 	dir := t.TempDir()
 	writeTestConfig(t, dir, "test-feed.yml", `

--- a/app/jobs/handlers.go
+++ b/app/jobs/handlers.go
@@ -149,9 +149,34 @@ func DownloadMediaHandler(
 		fileID := media.MediaFileID(item.GUID)
 		mediaPath := fileID + ".mp3"
 
+		// Load min_duration setting for filtering short videos
+		dbFeed, err := feedRepo.GetFeedByID(job.FeedID)
+		if err != nil {
+			return fmt.Errorf("failed to get feed: %w", err)
+		}
+		if dbFeed == nil {
+			return fmt.Errorf("feed not found for ID: %s", job.FeedID)
+		}
+		settings, err := dbFeed.GetSettings()
+		if err != nil {
+			return fmt.Errorf("failed to get feed settings: %w", err)
+		}
+		minDuration := settings.MinDuration
+
 		// Layer 1: DB check — does any item already have this file ready?
 		if existing, _ := itemRepo.GetReadyMediaByPath(mediaPath); existing != nil {
-			if err := itemRepo.UpdateMediaStatus(*job.ItemID, "ready", existing.MediaPath, existing.MediaSize, existing.ITunesDuration); err != nil {
+			existingDuration := existing.ITunesDuration
+			// If duration wasn't recorded (e.g. downloaded before duration tracking),
+			// probe the file so min_duration can be enforced.
+			if minDuration > 0 && existingDuration <= 0 {
+				if probedDuration, err := media.GetAudioDuration(mediaDir, existing.MediaPath); err == nil && probedDuration > 0 {
+					existingDuration = probedDuration
+				}
+			}
+			if minDuration > 0 && existingDuration > 0 && existingDuration < minDuration {
+				return filterShortVideo(itemRepo, *job.ItemID, existingDuration, minDuration)
+			}
+			if err := itemRepo.UpdateMediaStatus(*job.ItemID, "ready", existing.MediaPath, existing.MediaSize, existingDuration); err != nil {
 				return fmt.Errorf("failed to update media status (reuse): %w", err)
 			}
 			return nil
@@ -159,7 +184,13 @@ func DownloadMediaHandler(
 
 		// Layer 2: Filesystem check — file exists but DB doesn't know
 		if size, ok := media.FileExists(mediaDir, mediaPath); ok {
-			duration, _ := media.GetAudioDuration(mediaDir, mediaPath)
+			duration, err := media.GetAudioDuration(mediaDir, mediaPath)
+			if err != nil && minDuration > 0 {
+				slog.Warn("Could not probe duration for min_duration check, proceeding without filtering", "item_id", *job.ItemID, "error", err)
+			}
+			if minDuration > 0 && duration > 0 && duration < minDuration {
+				return filterShortVideo(itemRepo, *job.ItemID, duration, minDuration)
+			}
 			if err := itemRepo.UpdateMediaStatus(*job.ItemID, "ready", mediaPath, size, duration); err != nil {
 				return fmt.Errorf("failed to update media status (filesystem): %w", err)
 			}
@@ -174,6 +205,8 @@ func DownloadMediaHandler(
 		var duration int
 		videoInfo, err := media.GetVideoInfo(ctx, ytdlpCmd, item.Link)
 		if err != nil {
+			// Metadata failure is not fatal — proceed and rely on post-download
+			// ffprobe for the authoritative duration check.
 			slog.Warn("Video info check failed, proceeding with download", "item_id", *job.ItemID, "error", err)
 		} else if reschedule := videoReschedule(videoInfo); reschedule != nil {
 			slog.Info("Video not ready for download",
@@ -181,6 +214,10 @@ func DownloadMediaHandler(
 			return reschedule
 		} else {
 			duration = videoInfo.Duration
+		}
+
+		if minDuration > 0 && duration > 0 && duration < minDuration {
+			return filterShortVideo(itemRepo, *job.ItemID, duration, minDuration)
 		}
 
 		// Layer 4: Actually download
@@ -199,6 +236,13 @@ func DownloadMediaHandler(
 					fmt.Errorf("downloaded file is truncated: got %ds, expected ~%ds (VOD likely still processing)", probeDuration, duration))
 			}
 			duration = probeDuration
+		}
+
+		// Post-download min_duration check using authoritative ffprobe duration.
+		// Catches cases where pre-download metadata was unavailable or inaccurate.
+		if minDuration > 0 && duration > 0 && duration < minDuration {
+			os.Remove(filepath.Join(mediaDir, path))
+			return filterShortVideo(itemRepo, *job.ItemID, duration, minDuration)
 		}
 
 		if err := itemRepo.UpdateMediaStatus(*job.ItemID, "ready", path, size, duration); err != nil {
@@ -248,6 +292,20 @@ func handleMediaFailure(itemRepo *database.ItemRepository, itemID string, job *d
 		return nil
 	}
 	return fmt.Errorf("media download failed: %w", mediaErr)
+}
+
+func filterShortVideo(itemRepo *database.ItemRepository, itemID string, duration, minDuration int) error {
+	slog.Info("Video below min_duration, filtering",
+		"item_id", itemID, "duration", duration, "min_duration", minDuration)
+	if err := itemRepo.UpdateItemFilterStatus(itemID, true); err != nil {
+		return fmt.Errorf("failed to filter short video: %w", err)
+	}
+	// Also mark media as skipped so the item stays hidden even if Refilter()
+	// clears is_filtered (refilter only knows about pattern-based filters).
+	if err := itemRepo.UpdateMediaStatus(itemID, "skipped", "", 0, duration); err != nil {
+		return fmt.Errorf("failed to update media status for short video: %w", err)
+	}
+	return nil
 }
 
 // videoReschedule returns a RescheduleError only for unambiguous pre-download

--- a/app/types/feed.go
+++ b/app/types/feed.go
@@ -7,6 +7,7 @@ type Settings struct {
 	MaxItems        int  `yaml:"max_items" json:"max_items"`
 	Timeout         int  `yaml:"timeout" json:"timeout"`
 	ExtractContent bool `yaml:"extract_content" json:"extract_content"`
+	MinDuration    int  `yaml:"min_duration" json:"min_duration"`
 }
 
 type Filter struct {


### PR DESCRIPTION
  YouTube-only setting that filters out videos shorter than the configured
  threshold (in seconds). Checked against yt-dlp metadata before download,
  so no bandwidth is wasted. Filtered items are marked as is_filtered.